### PR TITLE
Unify template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,17 @@ Under non production scenario, you can use [ethereal](https://ethereal.email/) a
 
 ##### templateId
 
-*Required*</br>
 type: `string`
 
-The mail template to use declared on your configuration file.
+If it is present, it will be generate `text` and `html` using the template.
+
+##### text
+
+The plain text content version of the email notification.
+
+##### html
+
+The HTML content version of the email notification.
 
 ##### from
 
@@ -326,6 +333,12 @@ It sends a telegram message to the specified chat id.
 
 #### Data Params
 
+##### templateId
+
+type: `string`
+
+If it is present, it will be generate `text` using the template.
+
 ##### chatId
 
 *Required*</br>
@@ -333,9 +346,10 @@ type: `number`
 
 The Telegram chat id that will receive the message.
 
-##### message
+##### text
 
-type: `string`</br>
+*Required*</br>
+type: `string`
 
 The message that will be sent.
 
@@ -343,22 +357,35 @@ The message that will be sent.
 
 <small>`POST`</small>
 
-It sends a slack message.
+It sends a Slack message.
 
 #### Data Params
+
+##### webhook
+
+*Required*</br>
+type: `string`
+
+The Slack webhook endpoint for sending the data.
+
+##### templateId
+
+Type: `string`
+
+If it is present, it will be generate `text` using the template.
 
 ##### text
 
 *Required*</br>
 type: `string`
 
-The text of the message
+The text of the message.
 
 ##### attachments
 
 type: `object`</br>
 
-The message attachments, you cand find more information in the [Slack Documentation](https://api.slack.com/docs/message-attachments#attachment_structure)
+The message attachments, you can find more information at [Slack Documentation](https://api.slack.com/docs/message-attachments#attachment_structure)
 
 ## Environment Variables
 
@@ -407,13 +434,6 @@ Type: `string` </br>
 Default: `config.email.transporter.auth.user`
 
 Your SMTP authentication user credential.
-
-## TOM_SLACK_WEBHOOK
-
-Type: `string` </br>
-Default: `config.slack.webhook`
-
-Your Slack webhook URL.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - It processes payment via [Stripe](https://stripe.com).
 - It creates new customers and associate your pricing plans.
 - It subscribes customers into plans.
-- It sends transactional emails.
+- It sends transactional notifications (email, slack, telegram).
 
 **tom** does the things you do not want to do, it's your best friend 🐶.
 

--- a/src/commands/notification/email.js
+++ b/src/commands/notification/email.js
@@ -29,7 +29,7 @@ module.exports = ({ config }) => {
     }
   })
 
-  const { template } = config.email
+  const template = get(config, 'email.template')
 
   const email = async (opts, { printLog = true } = {}) => {
     opts.templateId &&

--- a/src/commands/notification/slack.js
+++ b/src/commands/notification/slack.js
@@ -7,7 +7,7 @@ const { ward, is } = require('../../ward')
 const compile = require('../../compile')
 
 module.exports = ({ config }) => {
-  const { template } = config.slack
+  const template = get(config, 'slack.template')
 
   const slack = async ({ webhook, ...opts }, { printLog = true } = {}) => {
     ward(webhook, { label: 'webhook', test: is.string.nonEmpty })

--- a/src/commands/notification/slack.js
+++ b/src/commands/notification/slack.js
@@ -25,7 +25,7 @@ module.exports = ({ config }) => {
       template: get(template, opts.templateId)
     })
 
-    ward(slackOpts.from, { label: 'text', test: is.string.nonEmpty })
+    ward(slackOpts.text, { label: 'text', test: is.string.nonEmpty })
 
     const { body: log } = await got(webhook, {
       body: JSON.stringify(slackOpts)

--- a/src/commands/notification/telegram.js
+++ b/src/commands/notification/telegram.js
@@ -13,8 +13,7 @@ module.exports = ({ config }) => {
   })
   if (errFn) return errFn
 
-  const { template } = config.telegram
-
+  const template = get(config, 'telegram.template')
   const token = get(config, 'telegram.token')
 
   const endpoint = `https://api.telegram.org/bot${token}/sendMessage`

--- a/src/compile.js
+++ b/src/compile.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { pick } = require('lodash')
+const deepMap = require('deep-map')
+
+const pupa = require('pupa')
+
+const compile = (template, opts) => deepMap(template, str => pupa(str, opts))
+
+module.exports = ({ template, config, opts, pickProps }) => {
+  const tpl = compile(template, { ...config, props: opts })
+  // assign props in order to replace props over config
+  return { ...pick(tpl, pickProps), ...pick(opts, pickProps) }
+}

--- a/src/compile.js
+++ b/src/compile.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pick } = require('lodash')
+const { pick, isNil } = require('lodash')
 const deepMap = require('deep-map')
 
 const pupa = require('pupa')
@@ -8,7 +8,10 @@ const pupa = require('pupa')
 const compile = (template, opts) => deepMap(template, str => pupa(str, opts))
 
 module.exports = ({ template, config, opts, pickProps }) => {
-  const tpl = compile(template, { ...config, props: opts })
+  const tpl = isNil(template)
+    ? opts
+    : compile(template, { ...config, props: opts })
+
   // assign props in order to replace props over config
   return { ...pick(tpl, pickProps), ...pick(opts, pickProps) }
 }

--- a/src/config/create.js
+++ b/src/config/create.js
@@ -23,7 +23,6 @@ module.exports = fn => {
   setEnv(config, 'email.transporter.auth.user', 'TOM_EMAIL_USER')
   setEnv(config, 'email.transporter.auth.pass', 'TOM_EMAIL_PASSWORD')
   setEnv(config, 'telegram.token', 'TOM_TELEGRAM_KEY')
-  setEnv(config, 'slack.webhook', 'TOM_SLACK_WEBHOOK')
 
   return { ...config, on, emit }
 }

--- a/test/commands/notification/slack.js
+++ b/test/commands/notification/slack.js
@@ -5,6 +5,8 @@ const test = require('ava')
 const createConfig = require('../../helpers/create-config')
 const createTom = require('../../../')
 
+const { TESTING_SLACK_WEBHOOK } = process.env
+
 test('notification:slack', async t => {
   const config = createConfig(({ config, tom }) => {
     tom.on('notification:slack', data => {
@@ -14,6 +16,7 @@ test('notification:slack', async t => {
 
   const tom = createTom(config)
   const text = 'Someone is running the tests 🙀'
+  const webhook = TESTING_SLACK_WEBHOOK
 
-  await tom.notification.slack({ text })
+  await tom.notification.slack({ webhook, text })
 })

--- a/test/commands/notification/telegram.js
+++ b/test/commands/notification/telegram.js
@@ -5,19 +5,19 @@ const test = require('ava')
 const createConfig = require('../../helpers/create-config')
 const createTom = require('../../../')
 
-const { TELEGRAM_TEST_CHAT_ID } = process.env
+const { TESTING_TELEGRAM_CHAT_ID } = process.env
 
 test('notification:telegram', async t => {
   const config = createConfig(({ config, tom }) => {
     tom.on('notification:telegram', data => {
-      t.is(data.text, message)
+      t.is(data.text, text)
       t.is(data.chat.id, chatId)
     })
   })
 
   const tom = createTom(config)
-  const chatId = parseInt(TELEGRAM_TEST_CHAT_ID)
-  const message = 'Someone is running the tests 🙀'
+  const chatId = parseInt(TESTING_TELEGRAM_CHAT_ID)
+  const text = 'Someone is running the tests 🙀'
 
-  await tom.notification.telegram({ message, chatId })
+  await tom.notification.telegram({ text, chatId })
 })


### PR DESCRIPTION
- **notification/email**: Adding support for pass `html` and `text` without use template
- **notificatio/telegram**: Add template support and rename `message` into `text`
- **notification/slack**: Add template support and `webhook` is a value provided, not extracted from config.